### PR TITLE
fix: return proper value from BackpackToggle

### DIFF
--- a/library/ConstantTypes.ts
+++ b/library/ConstantTypes.ts
@@ -47,7 +47,7 @@ export type BackpackCore<T extends string = string, U extends string = string> =
       options?: [Toggle<T, U>?, Toggle<T, U>?, Toggle<T, U>?, Toggle<T, U>?, Toggle<T, U>?, Toggle<T, U>?];
       default_value?: BackpackCore['BackpackToggle']['Output'];
     };
-    Output: string;
+    Output: U;
   };
   BackpackSpacing: {
     Input: {


### PR DESCRIPTION
Right now this returns only `string` which clashes with the `text_align` property for example. 

`text_align: BackpackCore<TextAlignKeys, TextAlign>['BackpackToggle'];`

when applied this returned only `string`. with the fix, it returns the proper `'inherit' | 'start' | 'center' | 'end'`

not sure if it's the right way of fixing it.