### PR TITLE
feat(GenericStoryblokReturnTypes): add email linkType to multilink

### DIFF
--- a/GenericStoryblokReturnTypes.d.ts
+++ b/GenericStoryblokReturnTypes.d.ts
@@ -9,7 +9,8 @@ export interface GenericReturnTypeMultilink {
     returnType: {
         id: string;
         url: string;
-        linktype: 'url' | 'story';
+        email?: string;
+        linktype: 'url' | 'story' | 'email';
         cached_url: string;
     };
 }


### PR DESCRIPTION
Hi, I'm adding the email linkType: GenericStoryblokReturnTypes.d
https://centralcreativestudio.atlassian.net/jira/software/c/projects/GCTT/boards/43?selectedIssue=GCTT-2192
![image](https://github.com/user-attachments/assets/b8011d9f-1879-48aa-b600-bbf1cb9d352e)
