### PR TITLE
fix: bring back the string type for field number - becasue.. storyblok

### DIFF
--- a/StoryblokReturnTypes.d.ts
+++ b/StoryblokReturnTypes.d.ts
@@ -8,7 +8,7 @@ export interface StoryblokMultilinkFieldReturnType {
   target?: "_blank";
   anchor?: string;
 }
-export type StoryblokNumberFieldReturnType = number;
+export type StoryblokNumberFieldReturnType = string;
 export type StoryblokDatetimeFieldReturnType = string;
 export type StoryblokBooleanFieldReturnType = boolean;
 export type StoryblokTextFieldReturnType = string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "storyblok-schema-types",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "storyblok-schema-types",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "ISC",
       "devDependencies": {
         "@storyblok/react": "^1.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storyblok-schema-types",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "",
   "main": "./index.d.ts",
   "types": "./index.d.ts",


### PR DESCRIPTION
It should properly return `number` but storyblok in json returns `string`...

created support for ticket on storyblok for that: https://support.storyblok.com/hc/en-us/requests/15509